### PR TITLE
Simplified make_rand_str function

### DIFF
--- a/common.php
+++ b/common.php
@@ -301,12 +301,7 @@ function str_compact ($str)
 
 function make_rand_str ($len = 10)
 {
-	$str = '';
-	while (strlen($str) < $len)
-	{
-		$str .= str_shuffle(preg_replace('#[^0-9a-zA-Z]#', '', crypt(uniqid(mt_rand(), true))));
-	}
-	return substr($str, 0, $len);
+	return substr(str_shuffle(str_repeat('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', (int)$len)), 0, $len);
 }
 
 // bencode: based on OpenTracker


### PR DESCRIPTION
https://github.com/torrentpier/torrentpier/pull/575

Fixed: PHP Notice:  crypt(): No salt parameter was specified. You must use a randomly generated salt and a strong hash function to produce a secure hash.